### PR TITLE
Enable console recording in session replays

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -127,6 +127,7 @@ export function initMixpanelOnce() {
     record_heatmap_data: true,
     record_inline_images: true,
     record_collect_fonts: true,
+    record_console: true,
     record_mask_text_selector: "nope",
     record_block_selector: "nope",
     record_block_class: "nope",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"clsx": "^2.1.1",
 				"framer-motion": "^11.3.30",
 				"lucide-react": "^0.436.0",
-				"mixpanel-browser": "^2.71.0",
+				"mixpanel-browser": "^2.72.0",
 				"next": "^14.2.35",
 				"p-limit": "^6.1.0",
 				"react": "^18",
@@ -737,6 +737,16 @@
 				"mitt": "^3.0.0"
 			}
 		},
+		"node_modules/@mixpanel/rrweb-plugin-console-record": {
+			"version": "2.0.0-alpha.18.2",
+			"resolved": "https://registry.npmjs.org/@mixpanel/rrweb-plugin-console-record/-/rrweb-plugin-console-record-2.0.0-alpha.18.2.tgz",
+			"integrity": "sha512-Xkwh2gSdLqHRkWSXv8CPVCPQj5L85KnWc5DZQ0CXNRFgm2hTl5/YP6zfUubVs2JVXZHGcSGU+g7JVO2WcFJyyg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@mixpanel/rrweb": "^2.0.0-alpha.18",
+				"@mixpanel/rrweb-utils": "^2.0.0-alpha.18"
+			}
+		},
 		"node_modules/@mixpanel/rrweb-snapshot": {
 			"version": "2.0.0-alpha.18.2",
 			"resolved": "https://registry.npmjs.org/@mixpanel/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.2.tgz",
@@ -1043,7 +1053,6 @@
 			"integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
 			"devOptional": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"playwright": "1.56.1"
 			},
@@ -1851,7 +1860,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
 			"integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
 			"devOptional": true,
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
@@ -1862,7 +1870,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
 			"integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
 			"devOptional": true,
-			"peer": true,
 			"dependencies": {
 				"@types/react": "*"
 			}
@@ -1928,7 +1935,6 @@
 			"integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.49.0",
 				"@typescript-eslint/types": "8.49.0",
@@ -2181,7 +2187,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
 			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3304,7 +3309,6 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
 			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -3471,7 +3475,6 @@
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -5285,12 +5288,16 @@
 			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
 		},
 		"node_modules/mixpanel-browser": {
-			"version": "2.71.0",
-			"resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.71.0.tgz",
-			"integrity": "sha512-jKmDXe68/oQFgk/9ns9Z36bA0CJ31PH8Y77XTLLGfJvhsUPbvu+7Se9e281NejZF6+OMqx7cE+zFxToozYyNrA==",
+			"version": "2.74.0",
+			"resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.74.0.tgz",
+			"integrity": "sha512-FWifdAaI+8zKEROb9T+gy0NRZB0gaCC5iy20rDjZ3C+KCwCsJcITT6lAYErWbwwmk3Ei34JBjLsnrDLPYj+hOw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@mixpanel/rrweb": "2.0.0-alpha.18.2"
+				"@mixpanel/rrweb": "2.0.0-alpha.18.2",
+				"@mixpanel/rrweb-plugin-console-record": "2.0.0-alpha.18.2"
+			},
+			"engines": {
+				"node": ">=20 <26"
 			}
 		},
 		"node_modules/ms": {
@@ -5833,7 +5840,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.1",
@@ -6016,7 +6022,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -6028,7 +6033,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -6968,7 +6972,6 @@
 			"version": "3.4.10",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.10.tgz",
 			"integrity": "sha512-KWZkVPm7yJRhdu4SRSl9d4AK2wM3a50UsvgHZO7xY77NQr2V+fIrEuoDGQcbvswWvFGbS2f6e+jC/6WJm1Dl0w==",
-			"peer": true,
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
 				"arg": "^5.0.2",
@@ -7134,7 +7137,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7300,7 +7302,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
 			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"clsx": "^2.1.1",
 		"framer-motion": "^11.3.30",
 		"lucide-react": "^0.436.0",
-		"mixpanel-browser": "^2.71.0",
+		"mixpanel-browser": "^2.72.0",
 		"next": "^14.2.35",
 		"p-limit": "^6.1.0",
 		"react": "^18",

--- a/public/mixpanel.js
+++ b/public/mixpanel.js
@@ -57,6 +57,7 @@ if (mixpanel && mixpanel.init) {
 		args[1].record_mask_text_selector = mask;
 		args[1].record_inline_images = true;
 		args[1].record_collect_fonts = true;
+		args[1].record_console = true;
 		args[1].ignore_dnt = true;
 		args[1].batch_flush_interval_ms = 0;
 		args[1].api_payload_format = 'json';


### PR DESCRIPTION
This PR updates the Mixpanel initialization config to capture console logs and errors alongside session replays. 

### **Changes:**

- Set `record_console`: `true` in the Mixpanel init options in `lib/analytics.ts` and in `public/mixpanel.js`
- Updated Mixpanel JS SDK version (`mixpanel-browser`) in `package.json` and `package-lock.json` to `2.74.0` since console recording support was added in `2.72.0`

### **Testing:**

- Ran `npm run build` successfully.
- Spot-checked Mixpanel project for console errors in replays like [this one](https://mixpanel.com/project/3276012/view/3782804/app/profile#distinct_id=%24device%3A65581a1c-2f80-4940-80e3-ea6ed795cf0c&replay_id=25f33695-21a2-47fb-bf36-49766e4d608b)! 