### PR TITLE
deliverables: fix broken under-the-hood link

### DIFF
--- a/deliverables/gartner-product-analytics-demo.html
+++ b/deliverables/gartner-product-analytics-demo.html
@@ -619,7 +619,7 @@ result = ws.<span class="tok-fn">query</span>(
 </span>
     <h4 class="diff-title">the purpose-built engine (arb).</h4>
     <p>our proprietary database is built for sub-second, interactive behavioral queries at massive scale. unlike tools built on general-purpose warehouses or clickhouse, it handles complex, high-cardinality group-bys with minimal latency. this is why the pet-retailer&rsquo;s 25-hour warehouse query returns near-instantly here.</p>
-    <a class="docs" href="https://developer.mixpanel.com/docs/under-the-hood" target="_blank" rel="noopener"><span class="docs-k">docs</span>developer.mixpanel.com/docs/under-the-hood<svg class="ext" viewBox="0 0 12 12" aria-hidden="true"><path d="M3 9L9 3M9 3H4.5M9 3V7.5" stroke="currentColor" stroke-width="1.2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
+    <a class="docs" href="https://medium.com/mixpaneleng/under-the-hood-of-mixpanels-infrastructure-0c7682125e9b" target="_blank" rel="noopener"><span class="docs-k">docs</span>medium.com/mixpaneleng/under-the-hood<svg class="ext" viewBox="0 0 12 12" aria-hidden="true"><path d="M3 9L9 3M9 3H4.5M9 3V7.5" stroke="currentColor" stroke-width="1.2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
   </article>
   <article class="diff">
     <span class="diff-ic"><svg fill="currentColor" width="100%" height="100%" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/deliverables/gartner/product-analytics-demo.html
+++ b/deliverables/gartner/product-analytics-demo.html
@@ -631,7 +631,7 @@ result = ws.<span class="tok-fn">query</span>(
 </span>
     <h4 class="diff-title">the purpose-built engine (arb).</h4>
     <p>our proprietary database is built for sub-second, interactive behavioral queries at massive scale. unlike tools built on general-purpose warehouses or clickhouse, it handles complex, high-cardinality group-bys with minimal latency. this is why the pet-retailer&rsquo;s 25-hour warehouse query returns near-instantly here.</p>
-    <a class="docs" href="https://developer.mixpanel.com/docs/under-the-hood" target="_blank" rel="noopener"><span class="docs-k">docs</span>developer.mixpanel.com/docs/under-the-hood<svg class="ext" viewBox="0 0 12 12" aria-hidden="true"><path d="M3 9L9 3M9 3H4.5M9 3V7.5" stroke="currentColor" stroke-width="1.2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
+    <a class="docs" href="https://medium.com/mixpaneleng/under-the-hood-of-mixpanels-infrastructure-0c7682125e9b" target="_blank" rel="noopener"><span class="docs-k">docs</span>medium.com/mixpaneleng/under-the-hood<svg class="ext" viewBox="0 0 12 12" aria-hidden="true"><path d="M3 9L9 3M9 3H4.5M9 3V7.5" stroke="currentColor" stroke-width="1.2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg></a>
   </article>
   <article class="diff">
     <span class="diff-ic"><svg fill="currentColor" width="100%" height="100%" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Updates the dead `developer.mixpanel.com/docs/under-the-hood` link in both Gartner decks to the Medium engineering post (`medium.com/mixpaneleng/under-the-hood-of-mixpanels-infrastructure-...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)