### PR TITLE
oneoffs/dev: replace dead placeholder images

### DIFF
--- a/oneoffs/dev/index.html
+++ b/oneoffs/dev/index.html
@@ -495,7 +495,7 @@
 				<input type="button"
 					value="A generic input button">
 				<input type="image"
-					src="https://via.placeholder.com/80x30.png?text=Submit"
+					src="https://repository-images.githubusercontent.com/519348881/d411fd39-0622-443e-8082-8783ccf386c8"
 					alt="Submit button"
 					width="80"
 					height="30">
@@ -509,7 +509,7 @@
 
 			<h3>Images</h3>
 			<figure>
-				<img src="https://via.placeholder.com/400x150.png?text=Standard+IMG+Tag"
+				<img src="https://repository-images.githubusercontent.com/519348881/d411fd39-0622-443e-8082-8783ccf386c8"
 					alt="A placeholder image"
 					usemap="#image-map">
 				<figcaption>A <code>&lt;figcaption&gt;</code> for the image above.</figcaption>
@@ -528,11 +528,11 @@
 
 			<h3>Picture Element</h3>
 			<picture>
-				<source srcset="https://via.placeholder.com/600x200.png?text=Large+Screen"
+				<source srcset="https://repository-images.githubusercontent.com/519348881/d411fd39-0622-443e-8082-8783ccf386c8"
 					media="(min-width: 600px)">
-				<source srcset="https://via.placeholder.com/300x100.png?text=Small+Screen"
+				<source srcset="https://repository-images.githubusercontent.com/519348881/d411fd39-0622-443e-8082-8783ccf386c8"
 					media="(min-width: 300px)">
-				<img src="https://via.placeholder.com/150x50.png?text=Default"
+				<img src="https://repository-images.githubusercontent.com/519348881/d411fd39-0622-443e-8082-8783ccf386c8"
 					alt="A responsive image">
 			</picture>
 
@@ -549,7 +549,7 @@
 			<!-- <video width="320"
 				height="240"
 				controls
-				poster="https://via.placeholder.com/320x240.png?text=Video+Poster">
+				poster="https://repository-images.githubusercontent.com/519348881/d411fd39-0622-443e-8082-8783ccf386c8">
 				<source src="movie.mp4"
 					type="video/mp4">
 				<source src="movie.ogg"


### PR DESCRIPTION
`via.placeholder.com` is offline, so all placeholder images in the dev demo were broken. Swap them for a stable GitHub-hosted image. Verified locally: all live `<img>`/`<picture>` placeholders render (the `src="#"` images are intentional broken-image demos; the video/audio posters are in commented-out blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)